### PR TITLE
fix: Add vulnerability flag to project summaries

### DIFF
--- a/app/models/project.py
+++ b/app/models/project.py
@@ -11,3 +11,4 @@ class ProjectSummary(BaseModel):
     id: int
     name: str
     description: Optional[str] = None
+    is_vulnerable: bool

--- a/app/routers/projects.py
+++ b/app/routers/projects.py
@@ -103,7 +103,12 @@ async def get_projects() -> list[ProjectSummary]:
     Returns a summary of all projects.
     """
     projects_data = store.get_all_projects()
-    return [ProjectSummary(**p) for p in projects_data]
+    summaries = []
+    for p in projects_data:
+        deps = store.get_dependencies_by_project_id(p["id"])
+        is_vulnerable = any(d["is_vulnerable"] for d in deps if d["is_vulnerable"] is not None)
+        summaries.append(ProjectSummary(**p, is_vulnerable=is_vulnerable))
+    return summaries
 
 
 @router.get("/{project_id}/dependencies", response_model=List[Dependency])

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -191,6 +191,7 @@ def test_get_all_projects(monkeypatch):
     assert projects[0]["id"] == 1
     assert projects[0]["name"] == "My First Project"
     assert projects[0]["description"] == "A description"
+    assert projects[0]["is_vulnerable"] is False
 
 
 def test_get_project_dependencies(monkeypatch):


### PR DESCRIPTION
The  endpoint was not indicating whether a project contained vulnerable dependencies. This commit fixes the issue by:

- Adding the  boolean field to the  model.
- Updating the  endpoint to calculate and include this flag in the response for each project.
- Updating the corresponding tests to assert the presence and correctness of the new flag.