### PR TITLE
feat: Add endpoint for dependency details and versions

### DIFF
--- a/app/data/store.py
+++ b/app/data/store.py
@@ -54,6 +54,66 @@ def get_all_dependencies() -> List[Dict]:
     return _dependencies
 
 
+def get_dependency_details(name: str, version: Optional[str] = None) -> List[Dict]:
+    """
+    Returns details for a dependency, including all projects that use it.
+    If version is specified, it returns details for that specific version.
+    """
+    if version:
+        deps = [d for d in _dependencies if d["name"] == name and d["version"] == version]
+    else:
+        deps = [d for d in _dependencies if d["name"] == name]
+
+    if not deps:
+        return []
+
+    # Although we might have multiple dependency records for the same name/version
+    # (one for each project that uses it), the core details will be the same.
+    # We can take the details from the first record we found.
+    first_dep = deps[0]
+
+    # Find all projects that use this dependency (any version if not specified)
+    project_ids = {d["project_id"] for d in deps}
+    projects_using_dep = list(
+        {p["name"] for p in _projects if p["id"] in project_ids}
+    )
+
+    details = {
+        "name": first_dep["name"],
+        "version": first_dep["version"],
+        "is_vulnerable": first_dep["is_vulnerable"],
+        "vulnerability_ids": first_dep["vulnerability_ids"],
+        "projects": projects_using_dep,
+        "queried_at": first_dep["queried_at"],
+    }
+    
+    # If no version is specified, we should return a list of details for each version
+    if not version:
+        # Group dependencies by version
+        deps_by_version: Dict[str, List[Dict]] = {}
+        for d in deps:
+            deps_by_version.setdefault(d["version"], []).append(d)
+
+        results = []
+        for ver, version_deps in deps_by_version.items():
+            first_ver_dep = version_deps[0]
+            project_ids = {d["project_id"] for d in version_deps}
+            projects_using_dep = list(
+                {p["name"] for p in _projects if p["id"] in project_ids}
+            )
+            results.append({
+                "name": first_ver_dep["name"],
+                "version": ver,
+                "is_vulnerable": first_ver_dep["is_vulnerable"],
+                "vulnerability_ids": first_ver_dep["vulnerability_ids"],
+                "projects": projects_using_dep,
+                "queried_at": first_ver_dep["queried_at"],
+            })
+        return results
+
+    return [details]
+
+
 def clear_projects_store():
     """Clears all projects from the store (for testing)."""
     global _next_project_id

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,12 +1,20 @@
-from .osv import OSVBatchResponse, QueryVulnerabilities, OSVAbbreviatedVulnerability
-from .project import ProjectResponse, ProjectSummary
-from .dependency import Dependency
+from .osv import (
+    OSVAbbreviatedVulnerability,
+    OSVBatchResponse,
+    QueryVulnerabilities,
+)
+from .project import Project, ProjectCreate, ProjectResponse, ProjectSummary
+from .dependency import Dependency, DependencyDetail
+
 
 __all__ = [
+    "OSVAbbreviatedVulnerability",
     "OSVBatchResponse",
     "QueryVulnerabilities",
-    "OSVAbbreviatedVulnerability",
+    "Project",
+    "ProjectCreate",
     "ProjectResponse",
     "ProjectSummary",
     "Dependency",
+    "DependencyDetail",
 ]

--- a/app/models/dependency.py
+++ b/app/models/dependency.py
@@ -1,5 +1,8 @@
+from datetime import datetime
 from typing import List
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+
+from app.models.project import ProjectSummary
 
 
 class Dependency(BaseModel):
@@ -7,3 +10,12 @@ class Dependency(BaseModel):
     version: str
     is_vulnerable: bool
     vulnerability_ids: List[str] = []
+
+
+class DependencyDetail(Dependency):
+    projects: List[str] = Field(
+        ...,
+        title="Projects",
+        description="List of project names using this dependency.",
+    )
+    queried_at: datetime

--- a/app/models/osv.py
+++ b/app/models/osv.py
@@ -1,6 +1,12 @@
 from pydantic import BaseModel, Field
 from typing import List
 
+
+class Query(BaseModel):
+    commit: str | None = None
+    package: dict | None = None
+
+
 class OSVAbbreviatedVulnerability(BaseModel):
     id: str
     modified: str

--- a/app/models/project.py
+++ b/app/models/project.py
@@ -1,14 +1,24 @@
 from pydantic import BaseModel
-from typing import Optional, List
+from typing import Optional
 
-# Define Pydantic models for the responses
-class ProjectResponse(BaseModel):
-    name: str
-    description: Optional[str]
-    is_vulnerable: bool
 
-class ProjectSummary(BaseModel):
-    id: int
+class ProjectBase(BaseModel):
     name: str
     description: Optional[str] = None
+
+
+class Project(ProjectBase):
+    id: int
+
+
+class ProjectCreate(ProjectBase):
+    pass
+
+
+# Define Pydantic models for the responses
+class ProjectResponse(ProjectBase):
+    is_vulnerable: bool
+
+
+class ProjectSummary(Project):
     is_vulnerable: bool

--- a/app/routers/dependencies.py
+++ b/app/routers/dependencies.py
@@ -1,8 +1,9 @@
 from typing import List
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
+from starlette import status
 
 from app.data import store
-from app.models.dependency import Dependency
+from app.models.dependency import Dependency, DependencyDetail
 
 
 router: APIRouter = APIRouter()
@@ -15,3 +16,18 @@ async def get_all_dependencies():
     """
     dependencies_data = store.get_all_dependencies()
     return [Dependency(**d) for d in dependencies_data]
+
+
+@router.get("/{name}", response_model=List[DependencyDetail])
+async def get_dependency(name: str, version: str | None = None):
+    """
+    Returns a list of all dependencies that have the same name.
+    If version is specified, it will return information about the exact dependency version.
+    """
+    dependency_details = store.get_dependency_details(name, version)
+    if not dependency_details:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Dependency '{name}' not found.",
+        )
+    return [DependencyDetail(**d) for d in dependency_details]

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -61,3 +61,77 @@ def test_get_all_dependencies(monkeypatch):
 
     assert dependencies[1]["name"] == "jinja2"
     assert dependencies[1]["is_vulnerable"] is True
+
+
+def test_get_dependency_by_name(monkeypatch):
+    """
+    Tests that GET /dependencies/{name} returns all versions of a dependency
+    if it exists in multiple projects.
+    """
+    # 1. Mock OSV responses
+    mock_osv_response_1 = OSVBatchResponse(
+        results=[QueryVulnerabilities(vulns=[])]
+    )
+    mock_osv_response_2 = OSVBatchResponse(
+        results=[QueryVulnerabilities(vulns=[])]
+    )
+    mock_query = AsyncMock(side_effect=[mock_osv_response_1, mock_osv_response_2])
+    monkeypatch.setattr("app.routers.projects.query_osv_batch", mock_query)
+
+    # 2. Create two projects with different versions of the same dependency
+    client.post(
+        "/projects/",
+        data={"name": "Project A"},
+        files={"file": ("requirements.txt", b"requests==2.28.1", "text/plain")},
+    )
+    client.post(
+        "/projects/",
+        data={"name": "Project B"},
+        files={"file": ("requirements.txt", b"requests==2.28.2", "text/plain")},
+    )
+
+    # 3. Get the dependency by name and verify both versions are returned
+    response = client.get("/dependencies/requests")
+    assert response.status_code == 200
+    details = response.json()
+    assert len(details) == 2
+    assert {d["version"] for d in details} == {"2.28.1", "2.28.2"}
+    assert details[0]["projects"] == ["Project A"]
+    assert details[1]["projects"] == ["Project B"]
+
+
+def test_get_dependency_by_name_and_version(monkeypatch):
+    """
+    Tests that GET /dependencies/{name}?version={version} returns the
+    correct specific version of a dependency.
+    """
+    # 1. Mock OSV response
+    mock_osv_response = OSVBatchResponse(results=[QueryVulnerabilities(vulns=[])])
+    mock_query = AsyncMock(return_value=mock_osv_response)
+    monkeypatch.setattr("app.routers.projects.query_osv_batch", mock_query)
+
+    # 2. Create a project
+    client.post(
+        "/projects/",
+        data={"name": "Project A"},
+        files={"file": ("requirements.txt", b"requests==2.28.1", "text/plain")},
+    )
+
+    # 3. Get the dependency by name and version
+    response = client.get("/dependencies/requests?version=2.28.1")
+    assert response.status_code == 200
+    details = response.json()
+    assert len(details) == 1
+    assert details[0]["name"] == "requests"
+    assert details[0]["version"] == "2.28.1"
+    assert details[0]["projects"] == ["Project A"]
+
+
+def test_get_dependency_not_found():
+    """
+    Tests that GET /dependencies/{name} returns a 404 for a
+    dependency that doesn't exist.
+    """
+    response = client.get("/dependencies/nonexistent-package")
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Dependency 'nonexistent-package' not found."


### PR DESCRIPTION
- Adds a new GET /dependencies/{name} endpoint to fetch details about a specific dependency.

- The endpoint supports an optional `version` query parameter to narrow down the results.

- Refactors Pydantic models to use inheritance, reducing code duplication.