### PR TITLE
Replace virtual environment approach with pip-compile for dependency …

### DIFF
--- a/tests/test_dependency_extractor.py
+++ b/tests/test_dependency_extractor.py
@@ -1,5 +1,5 @@
 import pytest
-from unittest.mock import patch, AsyncMock
+from unittest.mock import patch, AsyncMock, mock_open
 from app.services.dependency_extractor import extract_all_dependencies
 
 
@@ -11,21 +11,14 @@ class TestDependencyExtractor:
         """Test extraction with a single pinned dependency."""
         requirements = "requests==2.31.0"
         
-        # Mock the subprocess calls to return expected pip freeze output
-        with patch('asyncio.create_subprocess_exec') as mock_subprocess:
-            # Mock venv creation
+        # Mock the subprocess calls to return expected pip-compile output
+        with patch('asyncio.create_subprocess_exec') as mock_subprocess, \
+             patch('builtins.open', mock_open(read_data="certifi==2023.7.22\ncharset-normalizer==3.2.0\nidna==3.4\nrequests==2.31.0\nurllib3==2.0.4\n")):
+            
             mock_proc = AsyncMock()
             mock_proc.returncode = 0
             mock_proc.communicate = AsyncMock(return_value=(b"", b""))
             mock_subprocess.return_value = mock_proc
-            
-            # Mock pip freeze output for requests==2.31.0
-            mock_proc.communicate.side_effect = [
-                (b"", b""),  # venv creation
-                (b"", b""),  # pip upgrade
-                (b"", b""),  # pip install
-                (b"certifi==2023.7.22\ncharset-normalizer==3.2.0\nidna==3.4\nrequests==2.31.0\nurllib3==2.0.4\n", b"")  # pip freeze
-            ]
             
             result = await extract_all_dependencies(requirements)
             
@@ -42,19 +35,13 @@ class TestDependencyExtractor:
         """Test extraction with a single unpinned dependency."""
         requirements = "requests"
         
-        with patch('asyncio.create_subprocess_exec') as mock_subprocess:
+        with patch('asyncio.create_subprocess_exec') as mock_subprocess, \
+             patch('builtins.open', mock_open(read_data="certifi==2023.7.22\ncharset-normalizer==3.2.0\nidna==3.4\nrequests==2.31.0\nurllib3==2.0.4\n")):
+            
             mock_proc = AsyncMock()
             mock_proc.returncode = 0
             mock_proc.communicate = AsyncMock(return_value=(b"", b""))
             mock_subprocess.return_value = mock_proc
-            
-            # Mock pip freeze output for latest requests
-            mock_proc.communicate.side_effect = [
-                (b"", b""),  # venv creation
-                (b"", b""),  # pip upgrade
-                (b"", b""),  # pip install
-                (b"certifi==2023.7.22\ncharset-normalizer==3.2.0\nidna==3.4\nrequests==2.31.0\nurllib3==2.0.4\n", b"")  # pip freeze
-            ]
             
             result = await extract_all_dependencies(requirements)
             
@@ -70,19 +57,13 @@ class TestDependencyExtractor:
         """Test extraction with a dependency that has a version range."""
         requirements = "requests>=2.25.0,<3.0.0"
         
-        with patch('asyncio.create_subprocess_exec') as mock_subprocess:
+        with patch('asyncio.create_subprocess_exec') as mock_subprocess, \
+             patch('builtins.open', mock_open(read_data="certifi==2023.7.22\ncharset-normalizer==3.2.0\nidna==3.4\nrequests==2.31.0\nurllib3==2.0.4\n")):
+            
             mock_proc = AsyncMock()
             mock_proc.returncode = 0
             mock_proc.communicate = AsyncMock(return_value=(b"", b""))
             mock_subprocess.return_value = mock_proc
-            
-            # Mock pip freeze output for requests in the specified range
-            mock_proc.communicate.side_effect = [
-                (b"", b""),  # venv creation
-                (b"", b""),  # pip upgrade
-                (b"", b""),  # pip install
-                (b"certifi==2023.7.22\ncharset-normalizer==3.2.0\nidna==3.4\nrequests==2.31.0\nurllib3==2.0.4\n", b"")  # pip freeze
-            ]
             
             result = await extract_all_dependencies(requirements)
             
@@ -98,19 +79,13 @@ class TestDependencyExtractor:
         """Test extraction with a dependency that has extra requirements."""
         requirements = "requests[security]"
         
-        with patch('asyncio.create_subprocess_exec') as mock_subprocess:
+        with patch('asyncio.create_subprocess_exec') as mock_subprocess, \
+             patch('builtins.open', mock_open(read_data="certifi==2023.7.22\ncharset-normalizer==3.2.0\ncryptography==41.0.3\nidna==3.4\npyOpenSSL==23.2.0\nrequests==2.31.0\nurllib3==2.0.4\n")):
+            
             mock_proc = AsyncMock()
             mock_proc.returncode = 0
             mock_proc.communicate = AsyncMock(return_value=(b"", b""))
             mock_subprocess.return_value = mock_proc
-            
-            # Mock pip freeze output for requests with security extras
-            mock_proc.communicate.side_effect = [
-                (b"", b""),  # venv creation
-                (b"", b""),  # pip upgrade
-                (b"", b""),  # pip install
-                (b"certifi==2023.7.22\ncharset-normalizer==3.2.0\ncryptography==41.0.3\nidna==3.4\npyOpenSSL==23.2.0\nrequests==2.31.0\nurllib3==2.0.4\n", b"")  # pip freeze
-            ]
             
             result = await extract_all_dependencies(requirements)
             
@@ -128,19 +103,13 @@ class TestDependencyExtractor:
         """Test extraction with multiple dependencies."""
         requirements = "requests==2.31.0\nflask==2.3.3"
         
-        with patch('asyncio.create_subprocess_exec') as mock_subprocess:
+        with patch('asyncio.create_subprocess_exec') as mock_subprocess, \
+             patch('builtins.open', mock_open(read_data="blinker==1.6.2\ncertifi==2023.7.22\ncharset-normalizer==3.2.0\nclick==8.1.7\nflask==2.3.3\nidna==3.4\nitsdangerous==2.1.2\njinja2==3.1.2\nmarkupsafe==2.1.3\nrequests==2.31.0\nurllib3==2.0.4\nwerkzeug==2.3.7\n")):
+            
             mock_proc = AsyncMock()
             mock_proc.returncode = 0
             mock_proc.communicate = AsyncMock(return_value=(b"", b""))
             mock_subprocess.return_value = mock_proc
-            
-            # Mock pip freeze output for multiple packages
-            mock_proc.communicate.side_effect = [
-                (b"", b""),  # venv creation
-                (b"", b""),  # pip upgrade
-                (b"", b""),  # pip install
-                (b"blinker==1.6.2\ncertifi==2023.7.22\ncharset-normalizer==3.2.0\nclick==8.1.7\nflask==2.3.3\nidna==3.4\nitsdangerous==2.1.2\njinja2==3.1.2\nmarkupsafe==2.1.3\nrequests==2.31.0\nurllib3==2.0.4\nwerkzeug==2.3.7\n", b"")  # pip freeze
-            ]
             
             result = await extract_all_dependencies(requirements)
             
@@ -163,19 +132,13 @@ class TestDependencyExtractor:
         """Test extraction with requirements that include comments."""
         requirements = "# This is a comment\nrequests==2.31.0  # Another comment"
         
-        with patch('asyncio.create_subprocess_exec') as mock_subprocess:
+        with patch('asyncio.create_subprocess_exec') as mock_subprocess, \
+             patch('builtins.open', mock_open(read_data="certifi==2023.7.22\ncharset-normalizer==3.2.0\nidna==3.4\nrequests==2.31.0\nurllib3==2.0.4\n")):
+            
             mock_proc = AsyncMock()
             mock_proc.returncode = 0
             mock_proc.communicate = AsyncMock(return_value=(b"", b""))
             mock_subprocess.return_value = mock_proc
-            
-            # Mock pip freeze output
-            mock_proc.communicate.side_effect = [
-                (b"", b""),  # venv creation
-                (b"", b""),  # pip upgrade
-                (b"", b""),  # pip install
-                (b"certifi==2023.7.22\ncharset-normalizer==3.2.0\nidna==3.4\nrequests==2.31.0\nurllib3==2.0.4\n", b"")  # pip freeze
-            ]
             
             result = await extract_all_dependencies(requirements)
             
@@ -191,19 +154,13 @@ class TestDependencyExtractor:
         """Test extraction with requirements that include blank lines."""
         requirements = "requests==2.31.0\n\nflask==2.3.3"
         
-        with patch('asyncio.create_subprocess_exec') as mock_subprocess:
+        with patch('asyncio.create_subprocess_exec') as mock_subprocess, \
+             patch('builtins.open', mock_open(read_data="blinker==1.6.2\ncertifi==2023.7.22\ncharset-normalizer==3.2.0\nclick==8.1.7\nflask==2.3.3\nidna==3.4\nitsdangerous==2.1.2\njinja2==3.1.2\nmarkupsafe==2.1.3\nrequests==2.31.0\nurllib3==2.0.4\nwerkzeug==2.3.7\n")):
+            
             mock_proc = AsyncMock()
             mock_proc.returncode = 0
             mock_proc.communicate = AsyncMock(return_value=(b"", b""))
             mock_subprocess.return_value = mock_proc
-            
-            # Mock pip freeze output
-            mock_proc.communicate.side_effect = [
-                (b"", b""),  # venv creation
-                (b"", b""),  # pip upgrade
-                (b"", b""),  # pip install
-                (b"blinker==1.6.2\ncertifi==2023.7.22\ncharset-normalizer==3.2.0\nclick==8.1.7\nflask==2.3.3\nidna==3.4\nitsdangerous==2.1.2\njinja2==3.1.2\nmarkupsafe==2.1.3\nrequests==2.31.0\nurllib3==2.0.4\nwerkzeug==2.3.7\n", b"")  # pip freeze
-            ]
             
             result = await extract_all_dependencies(requirements)
             
@@ -222,71 +179,38 @@ class TestDependencyExtractor:
             assert result.endswith("\n")
 
     @pytest.mark.asyncio
-    async def test_venv_creation_failure(self):
-        """Test handling of virtual environment creation failure."""
+    async def test_pip_tools_installation_failure(self):
+        """Test handling of pip-tools installation failure."""
         requirements = "requests==2.31.0"
         
         with patch('asyncio.create_subprocess_exec') as mock_subprocess:
             mock_proc = AsyncMock()
             mock_proc.returncode = 1  # Simulate failure
-            mock_proc.communicate = AsyncMock(return_value=(b"", b"venv creation failed"))
+            mock_proc.communicate = AsyncMock(return_value=(b"", b"pip-tools installation failed"))
             mock_subprocess.return_value = mock_proc
             
-            with pytest.raises(RuntimeError, match="Failed to create virtualenv"):
+            with pytest.raises(RuntimeError, match="Failed to install pip-tools: pip-tools installation failed"):
                 await extract_all_dependencies(requirements)
 
     @pytest.mark.asyncio
-    async def test_pip_install_failure(self):
-        """Test handling of pip install failure."""
+    async def test_pip_compile_failure(self):
+        """Test handling of pip-compile failure."""
         requirements = "nonexistent-package==1.0.0"
         
         with patch('asyncio.create_subprocess_exec') as mock_subprocess:
             # Create separate mock processes for each call
-            mock_venv_proc = AsyncMock()
-            mock_venv_proc.returncode = 0
-            mock_venv_proc.communicate = AsyncMock(return_value=(b"", b""))
+            mock_install_proc = AsyncMock()
+            mock_install_proc.returncode = 0
+            mock_install_proc.communicate = AsyncMock(return_value=(b"", b""))
             
-            mock_pip_upgrade_proc = AsyncMock()
-            mock_pip_upgrade_proc.returncode = 0
-            mock_pip_upgrade_proc.communicate = AsyncMock(return_value=(b"", b""))
-            
-            mock_pip_install_proc = AsyncMock()
-            mock_pip_install_proc.returncode = 1  # Simulate failure
-            mock_pip_install_proc.communicate = AsyncMock(return_value=(b"", b"ERROR: Could not find a version that satisfies the requirement nonexistent-package==1.0.0"))
+            mock_compile_proc = AsyncMock()
+            mock_compile_proc.returncode = 1  # Simulate failure
+            mock_compile_proc.communicate = AsyncMock(return_value=(b"", b"ERROR: Could not find a version that satisfies the requirement nonexistent-package==1.0.0"))
             
             # Set up the mock to return different processes for different calls
-            mock_subprocess.side_effect = [mock_venv_proc, mock_pip_upgrade_proc, mock_pip_install_proc]
+            mock_subprocess.side_effect = [mock_install_proc, mock_compile_proc]
             
-            with pytest.raises(RuntimeError, match="Failed to install requirements"):
-                await extract_all_dependencies(requirements)
-
-    @pytest.mark.asyncio
-    async def test_pip_freeze_failure(self):
-        """Test handling of pip freeze failure."""
-        requirements = "requests==2.31.0"
-        
-        with patch('asyncio.create_subprocess_exec') as mock_subprocess:
-            # Create separate mock processes for each call
-            mock_venv_proc = AsyncMock()
-            mock_venv_proc.returncode = 0
-            mock_venv_proc.communicate = AsyncMock(return_value=(b"", b""))
-            
-            mock_pip_upgrade_proc = AsyncMock()
-            mock_pip_upgrade_proc.returncode = 0
-            mock_pip_upgrade_proc.communicate = AsyncMock(return_value=(b"", b""))
-            
-            mock_pip_install_proc = AsyncMock()
-            mock_pip_install_proc.returncode = 0
-            mock_pip_install_proc.communicate = AsyncMock(return_value=(b"", b""))
-            
-            mock_pip_freeze_proc = AsyncMock()
-            mock_pip_freeze_proc.returncode = 1  # Simulate failure
-            mock_pip_freeze_proc.communicate = AsyncMock(return_value=(b"", b"pip freeze failed"))
-            
-            # Set up the mock to return different processes for different calls
-            mock_subprocess.side_effect = [mock_venv_proc, mock_pip_upgrade_proc, mock_pip_install_proc, mock_pip_freeze_proc]
-            
-            with pytest.raises(RuntimeError, match="pip freeze failed"):
+            with pytest.raises(RuntimeError, match="pip-compile failed: ERROR: Could not find a version that satisfies the requirement nonexistent-package==1.0.0"):
                 await extract_all_dependencies(requirements)
 
     @pytest.mark.asyncio
@@ -294,101 +218,78 @@ class TestDependencyExtractor:
         """Test extraction with empty requirements."""
         requirements = ""
         
-        with patch('asyncio.create_subprocess_exec') as mock_subprocess:
+        with patch('asyncio.create_subprocess_exec') as mock_subprocess, \
+             patch('builtins.open', mock_open(read_data="")):
+            
             mock_proc = AsyncMock()
             mock_proc.returncode = 0
             mock_proc.communicate = AsyncMock(return_value=(b"", b""))
             mock_subprocess.return_value = mock_proc
-            
-            # Mock pip freeze output for empty environment
-            mock_proc.communicate.side_effect = [
-                (b"", b""),  # venv creation
-                (b"", b""),  # pip upgrade
-                (b"", b""),  # pip install
-                (b"", b""),  # pip freeze (empty)
-            ]
             
             result = await extract_all_dependencies(requirements)
             
-            assert result == "\n"  # Should return just a newline for empty output
+            assert result == "\n"
 
     @pytest.mark.asyncio
-    async def test_pip_freeze_output_without_newline(self):
-        """Test that the function handles pip freeze output that doesn't end with newline."""
+    async def test_pip_compile_output_without_newline(self):
+        """Test that the function handles pip-compile output that doesn't end with newline."""
         requirements = "requests==2.31.0"
         
-        with patch('asyncio.create_subprocess_exec') as mock_subprocess:
+        with patch('asyncio.create_subprocess_exec') as mock_subprocess, \
+             patch('builtins.open', mock_open(read_data="certifi==2023.7.22\ncharset-normalizer==3.2.0\nidna==3.4\nrequests==2.31.0\nurllib3==2.0.4")):
+            
             mock_proc = AsyncMock()
             mock_proc.returncode = 0
             mock_proc.communicate = AsyncMock(return_value=(b"", b""))
             mock_subprocess.return_value = mock_proc
-            
-            # Mock pip freeze output without trailing newline
-            mock_proc.communicate.side_effect = [
-                (b"", b""),  # venv creation
-                (b"", b""),  # pip upgrade
-                (b"", b""),  # pip install
-                (b"certifi==2023.7.22\ncharset-normalizer==3.2.0\nidna==3.4\nrequests==2.31.0\nurllib3==2.0.4", b"")  # pip freeze without newline
-            ]
             
             result = await extract_all_dependencies(requirements)
             
             assert "requests==2.31.0" in result
-            assert result.endswith("\n")  # Should add newline if missing
-
-    @pytest.mark.asyncio
-    async def test_windows_pip_path(self):
-        """Test that the function uses correct pip path on Windows."""
-        requirements = "requests==2.31.0"
-        
-        with patch('os.name', 'nt'), patch('asyncio.create_subprocess_exec') as mock_subprocess:
-            mock_proc = AsyncMock()
-            mock_proc.returncode = 0
-            mock_proc.communicate = AsyncMock(return_value=(b"", b""))
-            mock_subprocess.return_value = mock_proc
-            
-            # Mock pip freeze output
-            mock_proc.communicate.side_effect = [
-                (b"", b""),  # venv creation
-                (b"", b""),  # pip upgrade
-                (b"", b""),  # pip install
-                (b"certifi==2023.7.22\ncharset-normalizer==3.2.0\nidna==3.4\nrequests==2.31.0\nurllib3==2.0.4\n", b"")  # pip freeze
-            ]
-            
-            result = await extract_all_dependencies(requirements)
-            
-            # Verify that the correct Windows pip path was used
-            # Check that pip calls use the Windows Scripts/pip.exe path
-            pip_calls = [call for call in mock_subprocess.call_args_list if 'pip' in str(call)]
-            assert len(pip_calls) >= 3  # pip upgrade, pip install, pip freeze
-            
-            # Verify that the pip path contains Scripts/pip.exe (Windows path)
-            for call in pip_calls:
-                args = call[0]  # Get the arguments
-                if 'pip' in str(args):
-                    # The first argument should be the pip path
-                    pip_path = args[0]
-                    assert 'Scripts' in pip_path
-                    assert 'pip.exe' in pip_path
-            
-            assert "requests==2.31.0" in result
+            assert "certifi==2023.7.22" in result
+            assert "charset-normalizer==3.2.0" in result
+            assert "idna==3.4" in result
+            assert "urllib3==2.0.4" in result
             assert result.endswith("\n")
 
     @pytest.mark.asyncio
-    async def test_pip_upgrade_failure(self):
-        """Test that pip upgrade failures are properly handled."""
+    async def test_windows_pip_path(self):
+        """Test that the function uses correct Python executable on Windows."""
+        requirements = "requests==2.31.0"
+        
+        with patch('os.name', 'nt'), \
+             patch('asyncio.create_subprocess_exec') as mock_subprocess, \
+             patch('builtins.open', mock_open(read_data="certifi==2023.7.22\ncharset-normalizer==3.2.0\nidna==3.4\nrequests==2.31.0\nurllib3==2.0.4\n")):
+            
+            mock_proc = AsyncMock()
+            mock_proc.returncode = 0
+            mock_proc.communicate = AsyncMock(return_value=(b"", b""))
+            mock_subprocess.return_value = mock_proc
+            
+            result = await extract_all_dependencies(requirements)
+            
+            assert "requests==2.31.0" in result
+            assert "certifi==2023.7.22" in result
+            assert "charset-normalizer==3.2.0" in result
+            assert "idna==3.4" in result
+            assert "urllib3==2.0.4" in result
+            assert result.endswith("\n")
+
+    @pytest.mark.asyncio
+    async def test_pip_compile_failure_with_error_message(self):
+        """Test that pip-compile failures are properly handled."""
         with patch('asyncio.create_subprocess_exec') as mock_subprocess:
-            # Mock successful venv creation
-            mock_venv_proc = AsyncMock()
-            mock_venv_proc.communicate.return_value = (b"", b"")
-            mock_venv_proc.returncode = 0
+            # Mock successful pip-tools installation
+            mock_install_proc = AsyncMock()
+            mock_install_proc.communicate.return_value = (b"", b"")
+            mock_install_proc.returncode = 0
             
-            # Mock failed pip upgrade
-            mock_pip_upgrade_proc = AsyncMock()
-            mock_pip_upgrade_proc.communicate.return_value = (b"", b"Permission denied")
-            mock_pip_upgrade_proc.returncode = 1
+            # Mock failed pip-compile
+            mock_compile_proc = AsyncMock()
+            mock_compile_proc.communicate.return_value = (b"", b"Permission denied")
+            mock_compile_proc.returncode = 1
             
-            mock_subprocess.side_effect = [mock_venv_proc, mock_pip_upgrade_proc]
+            mock_subprocess.side_effect = [mock_install_proc, mock_compile_proc]
             
-            with pytest.raises(RuntimeError, match="Failed to upgrade pip: Permission denied"):
+            with pytest.raises(RuntimeError, match="pip-compile failed: Permission denied"):
                 await extract_all_dependencies("flask==2.0.1")


### PR DESCRIPTION
…extraction

- Replace pipdeptree + venv approach with pip-compile to avoid compilation issues
- pip-compile resolves dependencies without installation, avoiding httptools compilation errors
- Update all tests to mock the new pip-compile approach instead of venv creation
- Add missing tests for extract_dependencies_endpoint to achieve 100% coverage
- Successfully tested with uvicorn==0.11.6 which previously failed due to compilation issues