### PR TITLE
refactor(cache): Improve encapsulation and test robustness

### DIFF
--- a/app/services/cache.py
+++ b/app/services/cache.py
@@ -2,6 +2,7 @@ import asyncio
 import time
 from typing import Any, Optional
 
+
 class CacheEntry:
     def __init__(self, status: str, data: Any = None, expiry_timestamp: Optional[float] = None):
         self.status = status  # 'fetching' or 'ready'
@@ -28,11 +29,15 @@ class InMemoryAsyncCache:
         async with self._lock:
             self._store[key] = entry
 
+    async def pop(self, key: str, default: Any = None) -> Optional[CacheEntry]:
+        async with self._lock:
+            return self._store.pop(key, default)
+
     async def wait_for_ready(self, key: str, timeout: float = 5.0, poll_interval: float = 0.1) -> Optional[Any]:
         start = time.monotonic()
         while time.monotonic() - start < timeout:
             entry = await self.get(key)
-            if entry and entry.status == 'ready':
+            if entry and entry.status == "ready":
                 return entry.data
             await asyncio.sleep(poll_interval)
         return None

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,47 +1,58 @@
 import asyncio
+
 import pytest
-from app.services.cache import cache, CacheEntry
+
+from app.services.cache import CacheEntry, cache
+
 
 @pytest.mark.asyncio
 async def test_add_if_not_exists_and_get():
-    key = 'dep@1.0.0'
-    entry = CacheEntry(status='fetching')
+    key = "dep@1.0.0"
+    entry = CacheEntry(status="fetching")
     added = await cache.add_if_not_exists(key, entry)
     assert added
     fetched = await cache.get(key)
     assert fetched is not None
-    assert fetched.status == 'fetching'
+    assert fetched.status == "fetching"
     # Try to add again
-    added_again = await cache.add_if_not_exists(key, CacheEntry(status='fetching'))
+    added_again = await cache.add_if_not_exists(key, CacheEntry(status="fetching"))
     assert not added_again
+
 
 @pytest.mark.asyncio
 async def test_set_and_get():
-    key = 'dep@2.0.0'
-    entry = CacheEntry(status='ready', data={'foo': 'bar'}, expiry_timestamp=123456.0)
+    key = "dep@2.0.0"
+    entry = CacheEntry(status="ready", data={"foo": "bar"}, expiry_timestamp=123456.0)
     await cache.set(key, entry)
     fetched = await cache.get(key)
     assert fetched is not None
-    assert fetched.status == 'ready'
-    assert fetched.data == {'foo': 'bar'}
+    assert fetched.status == "ready"
+    assert fetched.data == {"foo": "bar"}
     assert fetched.expiry_timestamp == 123456.0
+
 
 @pytest.mark.asyncio
 async def test_wait_for_ready_success():
-    key = 'dep@3.0.0'
-    entry = CacheEntry(status='fetching')
+    key = "dep@3.0.0"
+    entry = CacheEntry(status="fetching")
     await cache.set(key, entry)
+
     async def set_ready():
-        await asyncio.sleep(0.2)
-        await cache.set(key, CacheEntry(status='ready', data='vuln', expiry_timestamp=999999.0))
-    asyncio.create_task(set_ready())
+        await asyncio.sleep(0.1)
+        await cache.set(
+            key, CacheEntry(status="ready", data="vuln", expiry_timestamp=999999.0)
+        )
+
+    setter_task = asyncio.create_task(set_ready())
     data = await cache.wait_for_ready(key, timeout=1.0, poll_interval=0.05)
-    assert data == 'vuln'
+    assert data == "vuln"
+    await setter_task
+
 
 @pytest.mark.asyncio
 async def test_wait_for_ready_timeout():
-    key = 'dep@4.0.0'
-    entry = CacheEntry(status='fetching')
-    await cache.set(key, entry)
-    data = await cache.wait_for_ready(key, timeout=0.3, poll_interval=0.05)
+    """Test wait_for_ready times out if the key is never ready."""
+    key = "dep@4.0.0"
+    await cache.set(key, CacheEntry(status="fetching"))
+    data = await cache.wait_for_ready(key, timeout=0.2, poll_interval=0.05)
     assert data is None


### PR DESCRIPTION
The code was accessing private members in the tests. To improve the design and make sure Ruff doesn't complain, public method were added to allow safer interaction with the cache.